### PR TITLE
修复参考文献引用行距问题

### DIFF
--- a/macro.tex
+++ b/macro.tex
@@ -136,3 +136,10 @@
 \usepackage{gbt7714}
 \bibliographystyle{gbt7714-numerical}
 \citestyle{numbers} % use number "[1]" instead of super "^{[1]}"
+
+\let\oldthebibliography\thebibliography
+\renewcommand\thebibliography[1]{%
+  \oldthebibliography{#1}%
+  \setlength{\parskip}{0pt}%
+  \setlength{\itemsep}{0pt}%
+}

--- a/macro.tex
+++ b/macro.tex
@@ -137,9 +137,14 @@
 \bibliographystyle{gbt7714-numerical}
 \citestyle{numbers} % use number "[1]" instead of super "^{[1]}"
 
-\let\oldthebibliography\thebibliography
-\renewcommand\thebibliography[1]{%
-  \oldthebibliography{#1}%
-  \setlength{\parskip}{0pt}%
-  \setlength{\itemsep}{0pt}%
+% set the separate spacing for lists like enum, item
+\setlist{
+  noitemsep,
+  topsep=0pt,
+  parsep=0pt,
+  partopsep=0pt,
+  leftmargin=*
 }
+
+%set the separate spacing for bibs
+\setlength{\bibsep}{0pt}


### PR DESCRIPTION
在当前的设置下，每条参考文献间的距离会比参考文献内的行距大。

本次修改修复了这个 Bug，使参考文献每行的行间距符合要求。

原本行距:
<img width="641" alt="Screenshot 2024-05-19 at 19 38 44" src="https://github.com/singularity-s0/fducs2024-thesis-template/assets/48545848/12e45416-d94c-42eb-b5ee-ab62949f587a">

修改后行距:
<img width="538" alt="Screenshot 2024-05-19 at 20 13 58" src="https://github.com/singularity-s0/fducs2024-thesis-template/assets/48545848/cefc4d6a-122a-4c38-b80c-ebe529bc5bf4">
